### PR TITLE
Using jmh for more reliable results

### DIFF
--- a/scala/normalization-bench/HOAS.scala
+++ b/scala/normalization-bench/HOAS.scala
@@ -5,6 +5,7 @@
 package normalization_bench
 
 import java.util.concurrent.TimeUnit
+import org.openjdk.jmh.annotations.{Benchmark, BenchmarkMode, Mode, OutputTimeUnit}
 
 abstract class Tm
 case class Var(x: Long) extends Tm
@@ -16,8 +17,33 @@ case class VVar(x: Long) extends Val
 case class VAp(t: Val, u: Val) extends Val
 case class VLam(t: Val => Val) extends Val
 
-
 object Main extends App {
+
+  @OutputTimeUnit(TimeUnit.MILLISECONDS)
+  @BenchmarkMode(Array(Mode.AverageTime))
+  class Bench {
+    @Benchmark
+    def Nat5Mconversion: Boolean = conv0(n5M, n5Mb)
+    @Benchmark
+    def Nat5Mnormalization: Boolean = force(quote0(n5M))
+    @Benchmark
+    def Nat10Mconversion: Boolean = conv0(n10M, n10Mb)
+    @Benchmark
+    def Nat10Mnormalization: Boolean = force(quote0(n10M))
+    @Benchmark
+    def Tree2Mconversion: Boolean = conv0(ap(fullTree, n20), ap(fullTree, n20b))
+    @Benchmark
+    def Tree2Mnormalization: Boolean = force(quote0(ap(fullTree, n20)))
+    @Benchmark
+    def Tree4Mconversion: Boolean = conv0(ap(fullTree, n21), ap(fullTree, n21b))
+    @Benchmark
+    def Tree4Mnormalization: Boolean = force(quote0(ap(fullTree, n21)))
+    @Benchmark
+    def Tree8Mconversion: Boolean = conv0(ap(fullTree, n22), ap(fullTree, n22b))
+    @Benchmark
+    def Tree8Mnormalization: Boolean =  force(quote0(ap(fullTree, n22)))
+  }
+
   def quote(l: Long, v:Val) : Tm = {
     v match {
       case VVar(x)   => Var(l - x - 1)
@@ -127,10 +153,10 @@ object Main extends App {
     println(s"\nAverage time: $avg ms")
   }
 
-  // Timed("Nat 5M conversion"     , 20, () => conv0(n5M, n5Mb))
-  // Timed("Nat 5M normalization"  , 20, () => force(quote0(n5M)))
-  // Timed("Nat 10M conversion"    , 20, () => conv0(n10M, n10Mb))
-  // Timed("Nat 10M normalization" , 20, () => force(quote0(n10M)))
+  Timed("Nat 5M conversion"     , 20, () => conv0(n5M, n5Mb))
+  Timed("Nat 5M normalization"  , 20, () => force(quote0(n5M)))
+  Timed("Nat 10M conversion"    , 20, () => conv0(n10M, n10Mb))
+  Timed("Nat 10M normalization" , 20, () => force(quote0(n10M)))
   Timed("Tree 2M conversion"    , 20, () => conv0(ap(fullTree, n20), ap(fullTree, n20b)))
   Timed("Tree 2M normalization" , 20, () => force(quote0(ap(fullTree, n20))))
   Timed("Tree 4M conversion"    , 20, () => conv0(ap(fullTree, n21), ap(fullTree, n21b)))

--- a/scala/normalization-bench/README.md
+++ b/scala/normalization-bench/README.md
@@ -1,4 +1,5 @@
 
 ### Scala normalization benchmark
 
-Running: use `export SBT_OPTS="-Xss500M -Xmx4G"` in command line, then `sbt`, then `run`.
+Running: use `export SBT_OPTS="-Xss1000M -Xmx4G"` in command line, then `sbt`, then `run` or `jmh:run --jvmArgs "-Xss1000M -Xmx4G` for more reliable results
+

--- a/scala/normalization-bench/build.sbt
+++ b/scala/normalization-bench/build.sbt
@@ -1,0 +1,7 @@
+lazy val root = (project in file(".")).
+  enablePlugins(JmhPlugin).
+  settings(
+    name := "normalization-bench",
+    version := "1.0",
+    scalaVersion := "2.13.2"
+  )

--- a/scala/normalization-bench/project/build.properties
+++ b/scala/normalization-bench/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.6
+sbt.version=1.3.12

--- a/scala/normalization-bench/project/plugins.sbt
+++ b/scala/normalization-bench/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("pl.project13.scala" % "sbt-jmh"             % "0.3.7")


### PR DESCRIPTION
Fix #7 

This give you reproducible results with marging of error.
You can see than even with all the care marging of error can be quite high

Ubuntu 20.04
5820K@4.4Ghz
16 GB RAM
mitigations=off
openjdk version "1.8.0_252"
OpenJDK Runtime Environment (build 1.8.0_252-8u252-b09-1ubuntu1-b09)
OpenJDK 64-Bit Server VM (build 25.252-b09, mixed mode)
[info] Benchmark                       Mode  Cnt     Score      Error  Units
[info] Main.Bench.Nat10Mconversion     avgt   25   753,237 ±   40,494  ms/op
[info] Main.Bench.Nat10Mnormalization  avgt   25  3907,007 ± 1046,009  ms/op
[info] Main.Bench.Nat5Mconversion      avgt   25   115,364 ±    5,987  ms/op
[info] Main.Bench.Nat5Mnormalization   avgt   25   314,185 ±   13,239  ms/op
[info] Main.Bench.Tree2Mconversion     avgt   25   102,050 ±    0,267  ms/op
[info] Main.Bench.Tree2Mnormalization  avgt   25    72,883 ±    0,187  ms/op
[info] Main.Bench.Tree4Mconversion     avgt   25   208,579 ±    0,476  ms/op
[info] Main.Bench.Tree4Mnormalization  avgt   25   145,012 ±    0,713  ms/op
[info] Main.Bench.Tree8Mconversion     avgt   25   444,941 ±    2,117  ms/op
[info] Main.Bench.Tree8Mnormalization  avgt   25   488,292 ±   16,404  ms/op
[success] Total time: 5217 s (01:26:57), completed 9 juin 2020 17:14:36

Overally your results still globally valid though.

|   | GHC HOAS CBV | GHC HOAS CBN | GHC interp CBV | OCaml HOAS | Scala 
|:--|:--------|:-------|:------|:----|:------
| Nat 5M conversion     | 83  | 79 | 163 | 85  | 115  | 115  | 1246     | N/A    | 31663 | 1208  | 3359  | 500
| Nat 5M normalization  | 92 | 102 | 133 | 218  | 314  | 314  | 69592    | 1507   | 2604  | 4309  | 4790  | 411
| Nat 10M conversion    | 191 | 150 | 490 | 428  | 753 | 753 | 4462     | N/A    | OOM   | 6965  | 5081  | 1681
| Nat 10M normalization | 209 | 238 | 331 | 558  | 3907 | 3907 | too long | 3340   | 5780  | 11216 | 13181 | 1148
| Tree 2M conversion    | 128 | 72 | 220 | 71  | 102  | 102  | 102    | N/A    | 477   | 561   | 691   | 425
| Tree 2M normalization | 82  | 60  | 129 | 98  | 72  | 72   | 72     | 1248   | 702   | 960   | 1103  | 346
| Tree 4M conversion    | 286 | 144 | 467 | 113  | 208  | 208  | 208      | N/A    | 646   | 1276  | 1302  | 1429
| Tree 4M normalization | 176 | 159 | 270 | 342  | 145  | 145  | 145     | 1365   | 1488  | 1729  | 1983  | 745
| Tree 8M conversion    | 704 | 289 | 1092| 236  | 444 | 444  | 444     | N/A    | 1279  | 2420  | 2901  | 2371
| Tree 8M normalization | 415 | 438 | 611 | 926 | 488 | 488  | 488     | 3275   | 2871  | 3464  | 3497  | 1544